### PR TITLE
Collect hash errors

### DIFF
--- a/src/error_collector.rs
+++ b/src/error_collector.rs
@@ -1,0 +1,59 @@
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct HashLookupError {
+    pub hash_id: u64,
+    pub source_file: String,
+}
+
+impl HashLookupError {
+    pub fn new(hash_id: u64, source_file: String) -> Self {
+        Self {
+            hash_id,
+            source_file,
+        }
+    }
+}
+
+impl fmt::Display for HashLookupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} - Cannot resolve hash {}",
+            self.source_file, self.hash_id
+        )
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ErrorCollector {
+    errors: Vec<HashLookupError>,
+}
+
+impl ErrorCollector {
+    pub fn new() -> Self {
+        Self { errors: Vec::new() }
+    }
+
+    pub fn add_error(&mut self, error: HashLookupError) {
+        self.errors.push(error);
+    }
+
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    pub fn error_count(&self) -> usize {
+        self.errors.len()
+    }
+
+    pub fn errors(&self) -> &[HashLookupError] {
+        &self.errors
+    }
+
+    pub fn print_errors(&self) {
+        for error in &self.errors {
+            eprintln!("{}", error);
+        }
+    }
+}

--- a/src/error_collector.rs
+++ b/src/error_collector.rs
@@ -25,34 +25,76 @@ impl fmt::Display for HashLookupError {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct LexerError {
+    pub message: String,
+    pub position: usize,
+    pub line: usize,
+}
+
+impl LexerError {
+    pub fn new(message: String, position: usize, line: usize) -> Self {
+        Self {
+            message,
+            position,
+            line,
+        }
+    }
+}
+
+impl fmt::Display for LexerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Lexer error at position {} (line {}): {}",
+            self.position, self.line, self.message
+        )
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct ErrorCollector {
-    errors: Vec<HashLookupError>,
+    hash_errors: Vec<HashLookupError>,
+    lexer_errors: Vec<LexerError>,
 }
 
 impl ErrorCollector {
     pub fn new() -> Self {
-        Self { errors: Vec::new() }
+        Self {
+            hash_errors: Vec::new(),
+            lexer_errors: Vec::new(),
+        }
     }
 
     pub fn add_error(&mut self, error: HashLookupError) {
-        self.errors.push(error);
+        self.hash_errors.push(error);
+    }
+
+    pub fn add_lexer_error(&mut self, message: String, position: usize, line: usize) {
+        self.lexer_errors.push(LexerError::new(message, position, line));
     }
 
     pub fn has_errors(&self) -> bool {
-        !self.errors.is_empty()
+        !self.hash_errors.is_empty() || !self.lexer_errors.is_empty()
     }
 
     pub fn error_count(&self) -> usize {
-        self.errors.len()
+        self.hash_errors.len() + self.lexer_errors.len()
     }
 
     pub fn errors(&self) -> &[HashLookupError] {
-        &self.errors
+        &self.hash_errors
+    }
+
+    pub fn lexer_errors(&self) -> &[LexerError] {
+        &self.lexer_errors
     }
 
     pub fn print_errors(&self) {
-        for error in &self.errors {
+        for error in &self.hash_errors {
+            eprintln!("{}", error);
+        }
+        for error in &self.lexer_errors {
             eprintln!("{}", error);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use util::common_util::{load_diff_file, parse_diff};
 use crate::parser::diff::parser::ExternalLoader;
 use crate::util::common_util::{filter_out_non_matching_versions, tokenize_qml};
 
+mod error_collector;
 mod hash;
 mod hashrules;
 mod hashtab;
@@ -100,6 +101,7 @@ extern "C" fn qmldiff_add_external_diff(
         change_file_contents,
         &file_identifier,
         &HASHTAB.lock().unwrap(),
+        None,
         None,
     ) {
         Err(problem) => {
@@ -194,6 +196,7 @@ extern "C" fn qmldiff_build_change_files(root_dir: *const c_char) -> i32 {
                     .lock()
                     .unwrap()
                     .map(|e| Box::new(e) as Box<dyn ExternalLoader>),
+                None,
             ) {
                 Err(problem) => {
                     eprintln!("[qmldiff]: Failed to load file {}: {:?}", file, problem)

--- a/src/parser/diff/hash_processor.rs
+++ b/src/parser/diff/hash_processor.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::{Error, Result};
 
 use crate::{
+    error_collector::{ErrorCollector, HashLookupError},
     hashtab::HashTab,
     parser::{
         common::{ChainIteratorRemapper, IteratorRemapper},
@@ -16,17 +17,33 @@ pub struct DiffHashRemapper<'a> {
     hashtab: &'a HashTab,
 }
 
-fn resolve_hashed_ids(hashtab: &HashTab, source_name: &str, id: &Vec<u64>) -> Result<String> {
+fn resolve_hashed_ids(
+    hashtab: &HashTab,
+    source_name: &str,
+    id: &Vec<u64>,
+    error_collector: &mut Option<&mut ErrorCollector>,
+) -> Result<String> {
     let mut out_id = String::new();
+
     for id in id {
         if out_id != "" { out_id += "." }
-        out_id += 
-        hashtab
-            .get(&id)
-            .ok_or(Error::msg(format!(
-                "Couldn't resolve the hashed identifier {} required by {}",
-                id, source_name
-            )))?;
+
+        if let Some(resolved) = hashtab.get(&id) {
+            out_id += resolved;
+        } else {
+            if let Some(ref mut collector) = error_collector {
+                collector.add_error(HashLookupError::new(
+                    *id,
+                    source_name.to_string(),
+                ));
+                out_id += &format!("__UNRESOLVED_HASH_{}", id);
+            } else {
+                return Err(Error::msg(format!(
+                    "Couldn't resolve the hashed identifier {} required by {}",
+                    id, source_name
+                )));
+            }
+        }
     }
 
     Ok(out_id)
@@ -37,11 +54,19 @@ pub fn diff_hash_remapper(
     hashtab: &HashTab,
     value: TokenType,
     source_name: &str,
+    error_collector: &mut Option<&mut ErrorCollector>,
 ) -> Result<TokenType> {
     match value {
-        TokenType::HashedValue(HashedValue::HashedIdentifier(id)) => Ok(TokenType::Identifier(resolve_hashed_ids(hashtab, source_name, &id)?)),
+        TokenType::HashedValue(HashedValue::HashedIdentifier(id)) => {
+            Ok(TokenType::Identifier(resolve_hashed_ids(
+                hashtab,
+                source_name,
+                &id,
+                error_collector,
+            )?))
+        }
         TokenType::HashedValue(HashedValue::HashedString(q, id)) => {
-            let unwrapped = resolve_hashed_ids(hashtab, source_name, &id)?;
+            let unwrapped = resolve_hashed_ids(hashtab, source_name, &id, error_collector)?;
             Ok(TokenType::String(if q != '`' {
                 format!("{}{}{}", q, unwrapped, q)
             } else {
@@ -55,7 +80,7 @@ pub fn diff_hash_remapper(
             Ok(TokenType::QMLCode {
                 qml_code: qml_code
                     .into_iter()
-                    .map(|e| match qml_hash_remap(hashtab, e, source_name) {
+                    .map(|e| match qml_hash_remap(hashtab, e, source_name, error_collector.as_deref_mut()) {
                         Ok(v) => v,
                         Err(e) => {
                             panic!("{:?}", e); // temporary solution.
@@ -75,7 +100,7 @@ impl IteratorRemapper<TokenType, Arc<String>> for DiffHashRemapper<'_> {
         value: TokenType,
         souce_name: &Arc<String>,
     ) -> ChainIteratorRemapper<TokenType> {
-        match diff_hash_remapper(self.hashtab, value, souce_name) {
+        match diff_hash_remapper(self.hashtab, value, souce_name, &mut None) {
             Ok(e) => ChainIteratorRemapper::Value(e),
             Err(e) => ChainIteratorRemapper::Error(e),
         }

--- a/src/parser/diff/hash_processor.rs
+++ b/src/parser/diff/hash_processor.rs
@@ -80,13 +80,8 @@ pub fn diff_hash_remapper(
             Ok(TokenType::QMLCode {
                 qml_code: qml_code
                     .into_iter()
-                    .map(|e| match qml_hash_remap(hashtab, e, source_name, error_collector.as_deref_mut()) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            panic!("{:?}", e); // temporary solution.
-                        }
-                    })
-                    .collect(),
+                    .map(|e| qml_hash_remap(hashtab, e, source_name, error_collector.as_deref_mut()))
+                    .collect::<Result<Vec<_>>>()?,
                 stream_character: is_stream,
             })
         }

--- a/src/parser/diff/lexer.rs
+++ b/src/parser/diff/lexer.rs
@@ -2,9 +2,12 @@ use std::{fmt::Display, mem::take};
 
 use anyhow::{Error, bail};
 
-use crate::parser::{
-    common::{CollectionType, StringCharacterTokenizer},
-    qml,
+use crate::{
+    error_collector::LexerError,
+    parser::{
+        common::{CollectionType, StringCharacterTokenizer},
+        qml,
+    },
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -143,7 +146,9 @@ pub enum TokenType {
 
 pub struct Lexer {
     pub stream: StringCharacterTokenizer,
-    pub line_pos: usize, // Current position within a line [unused.]
+    pub line_pos: usize,
+    pub collect_errors: bool,
+    pub errors: Vec<LexerError>,
 }
 
 impl Lexer {
@@ -151,7 +156,22 @@ impl Lexer {
         Self {
             stream: input,
             line_pos: 0,
+            collect_errors: false,
+            errors: Vec::new(),
         }
+    }
+
+    pub fn with_error_collection(input: StringCharacterTokenizer) -> Self {
+        Self {
+            stream: input,
+            line_pos: 0,
+            collect_errors: true,
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn take_errors(&mut self) -> Vec<LexerError> {
+        std::mem::take(&mut self.errors)
     }
     pub fn next_token(&mut self) -> Result<TokenType, Error> {
         if let Some(c) = self.stream.peek() {
@@ -238,6 +258,9 @@ impl Lexer {
                         let initial_token = qml_lexer.next_token()?;
                         loop {
                             let token = qml_lexer.next_token()?;
+                            if token == qml::lexer::TokenType::EndOfStream {
+                                bail!("Unexpected End-Of-Stream reached while processing STREAM block!");
+                            }
                             if token == initial_token {
                                 break;
                             }
@@ -309,8 +332,18 @@ impl Iterator for Lexer {
             match self.next_token() {
                 Ok(token) => return Some(token),
                 Err(e) => {
-                    // TODO: handle this
-                    panic!("Error while reading token: {e:?}");
+                    if self.collect_errors {
+                        self.errors.push(LexerError::new(
+                            e.to_string(),
+                            self.stream.position,
+                            self.line_pos,
+                        ));
+                        if self.stream.position < self.stream.input.len() {
+                            self.stream.advance();
+                        }
+                    } else {
+                        panic!("Error while reading token: {e:?}");
+                    }
                 }
             }
         }

--- a/src/parser/diff/parser.rs
+++ b/src/parser/diff/parser.rs
@@ -845,7 +845,7 @@ impl<'a> Parser<'a> {
                 if let Some(hashtab) = self.hashtab {
                     Lexer::new(StringCharacterTokenizer::new(file_contents))
                         .map(|e| {
-                            diff_hash_remapper(hashtab, e, &full_path.to_string_lossy()).unwrap()
+                            diff_hash_remapper(hashtab, e, &full_path.to_string_lossy(), &mut None).unwrap()
                         })
                         .collect::<Vec<TokenType>>()
                 } else {

--- a/src/parser/qml/hash_extension.rs
+++ b/src/parser/qml/hash_extension.rs
@@ -1,6 +1,7 @@
 use anyhow::{Error, Result};
 
 use crate::{
+    error_collector::{ErrorCollector, HashLookupError},
     hashtab::HashTab,
     parser::common::{ChainIteratorRemapper, IteratorRemapper},
 };
@@ -17,26 +18,49 @@ impl<'a> QMLHashRemapper<'a> {
     }
 }
 
-pub fn qml_hash_remap(hashtab: &HashTab, token: TokenType, source_name: &str) -> Result<TokenType> {
+pub fn qml_hash_remap(
+    hashtab: &HashTab,
+    token: TokenType,
+    source_name: &str,
+    error_collector: Option<&mut ErrorCollector>,
+) -> Result<TokenType> {
     match token {
         TokenType::Extension(QMLExtensionToken::HashedIdentifier(id)) => {
             if let Some(resolved) = hashtab.get(&id) {
                 Ok(TokenType::Identifier(resolved.clone()))
             } else {
-                Err(Error::msg(format!(
-                    "Cannot resolve hash {} required by {}!",
-                    id, source_name
-                )))
+                if let Some(collector) = error_collector {
+                    collector.add_error(HashLookupError::new(
+                        id,
+                        source_name.to_string(),
+                    ));
+                    // Return a placeholder to continue processing
+                    Ok(TokenType::Identifier(format!("__UNRESOLVED_HASH_{}", id)))
+                } else {
+                    Err(Error::msg(format!(
+                        "Cannot resolve hash {} required by {}!",
+                        id, source_name
+                    )))
+                }
             }
         }
         TokenType::Extension(QMLExtensionToken::HashedString(q, id)) => {
             if let Some(resolved) = hashtab.get(&id) {
                 Ok(TokenType::String(format!("{}{}{}", q, resolved, q)))
             } else {
-                Err(Error::msg(format!(
-                    "Cannot resolve hash {} required by {}!",
-                    id, source_name
-                )))
+                if let Some(collector) = error_collector {
+                    collector.add_error(HashLookupError::new(
+                        id,
+                        source_name.to_string(),
+                    ));
+                    // Return a placeholder to continue processing
+                    Ok(TokenType::String(format!("{}__UNRESOLVED_HASH_{}{}", q, id, q)))
+                } else {
+                    Err(Error::msg(format!(
+                        "Cannot resolve hash {} required by {}!",
+                        id, source_name
+                    )))
+                }
             }
         }
         other => Ok(other),
@@ -45,7 +69,7 @@ pub fn qml_hash_remap(hashtab: &HashTab, token: TokenType, source_name: &str) ->
 
 impl IteratorRemapper<TokenType, &str> for QMLHashRemapper<'_> {
     fn remap(&mut self, value: TokenType, source_name: &&str) -> ChainIteratorRemapper<TokenType> {
-        match qml_hash_remap(self.hashtab, value, source_name) {
+        match qml_hash_remap(self.hashtab, value, source_name, None) {
             Ok(e) => ChainIteratorRemapper::Value(e),
             Err(e) => ChainIteratorRemapper::Error(e),
         }

--- a/src/util/common_util.rs
+++ b/src/util/common_util.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, fs::read_to_string, path::Path, rc::Rc, sync::Arc};
 use anyhow::{Error, Result};
 
 use crate::{
+    error_collector::ErrorCollector,
     hashtab::HashTab,
     parser::{
         common::{IteratorPipeline, StringCharacterTokenizer},
@@ -67,6 +68,7 @@ pub fn load_diff_file<P>(
     file_path: P,
     hashtab: &HashTab,
     external_loader: Option<Box<dyn ExternalLoader>>,
+    error_collector: Option<&mut ErrorCollector>,
 ) -> Result<Vec<Change>>
 where
     P: AsRef<Path>,
@@ -78,6 +80,7 @@ where
         &file_path.as_ref().to_string_lossy(),
         hashtab,
         external_loader,
+        error_collector,
     )
 }
 
@@ -87,11 +90,18 @@ pub fn parse_diff(
     diff_name: &str,
     hashtab: &HashTab,
     external_loader: Option<Box<dyn ExternalLoader>>,
+    error_collector: Option<&mut ErrorCollector>,
 ) -> Result<Vec<Change>> {
     let lexer = diff::lexer::Lexer::new(StringCharacterTokenizer::new(contents));
-    let tokens: Vec<diff::lexer::TokenType> = lexer
-        .map(|e| diff_hash_remapper(hashtab, e, diff_name).unwrap())
-        .collect();
+    let tokens: Vec<diff::lexer::TokenType> = if let Some(collector) = error_collector {
+        lexer
+            .map(|e| diff_hash_remapper(hashtab, e, diff_name, &mut Some(collector)).unwrap())
+            .collect()
+    } else {
+        lexer
+            .map(|e| diff_hash_remapper(hashtab, e, diff_name, &mut None).unwrap())
+            .collect()
+    };
     let mut parser = diff::parser::Parser::new(
         Box::new(tokens.into_iter()),
         root_dir,


### PR DESCRIPTION
This PR adds the option to pass `--collect-hash-errors` to collect all hashing and QML parsing errors instead of exiting early. This is designed for the verification of qmd files against a QML tree. 